### PR TITLE
Fix: build error when cuda is detected

### DIFF
--- a/install/setup-opencv.js
+++ b/install/setup-opencv.js
@@ -68,6 +68,7 @@ function getSharedCmakeFlags() {
     '-DBUILD_TESTS=OFF',
     '-DBUILD_PERF_TESTS=OFF',
     '-DBUILD_JAVA=OFF',
+    '-DCUDA_NVCC_FLAGS=--expt-relaxed-constexpr',
     '-DBUILD_opencv_apps=OFF',
     '-DBUILD_opencv_aruco=OFF',
     '-DBUILD_opencv_bgsegm=OFF',


### PR DESCRIPTION
Added extra flag to `nvcc` to relax the requirements

Is there any sane way to test this change on multiple configurations? 