### PR TITLE
disabled cuda as build crash due to >=6 version of cuda conflict with opencv

### DIFF
--- a/install/setup-opencv.js
+++ b/install/setup-opencv.js
@@ -63,6 +63,7 @@ function getSharedCmakeFlags() {
     `-DCMAKE_INSTALL_PREFIX=${opencvBuild}`,
     '-DCMAKE_BUILD_TYPE=Release',
     `-DOPENCV_EXTRA_MODULES_PATH=${opencvContribModules}`,
+    '-DBUILD_CUDA=OFF',
     '-DBUILD_EXAMPLES=OFF',
     '-DBUILD_DOCS=OFF',
     '-DBUILD_TESTS=OFF',


### PR DESCRIPTION
while building opencv using ubuntu 18.04 and CUDA version >= 6, It is crashing.
