### PR TITLE
add the ability to customize build trhough process.env.OPENCV4NODEJS_…

### DIFF
--- a/install/setup-opencv.js
+++ b/install/setup-opencv.js
@@ -1,5 +1,5 @@
 const log = require('npmlog')
-const { exec, spawn, isWin } = require('./utils')
+const { exec, spawn, isWin, flags } = require('./utils')
 const findMsBuild = require('./find-msbuild')
 const {
   rootDir,
@@ -59,7 +59,8 @@ const cmakeArchs = {
 }
 
 function getSharedCmakeFlags() {
-  return [
+  const additionalFlags = flags();
+  const defaultFlags = [
     `-DCMAKE_INSTALL_PREFIX=${opencvBuild}`,
     '-DCMAKE_BUILD_TYPE=Release',
     '-DOPENCV_ENABLE_NONFREE=ON',
@@ -101,7 +102,8 @@ function getSharedCmakeFlags() {
     '-DBUILD_opencv_xobjdetect=OFF',
     '-DBUILD_opencv_xphoto=OFF',
     '-DWITH_VTK=OFF'
-  ]
+  ];
+  return defaultFlags.concat(additionalFlags);
 }
 
 function getWinCmakeFlags(msversion) {

--- a/install/utils.js
+++ b/install/utils.js
@@ -75,3 +75,12 @@ exports.isUnix = function() {
 exports.isAutoBuildDisabled = function() {
   return !!process.env.OPENCV4NODEJS_DISABLE_AUTOBUILD
 }
+
+exports.flags = function() {
+  const flagStr = process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS;
+  if(typeof(flagStr) === "string"){
+    log.silly('install', 'using flags from OPENCV4NODEJS_AUTOBUILD_FLAGS:', flagStr)
+    return flagStr.split(' ');
+  }
+  return [];
+}


### PR DESCRIPTION
…AUTOBUILD_FLAGS

One one hand, autobuild is very handy (for multiple reasons), but on the other hand, i would like to customize the build.

I would like to suggest adding this OPENCV4NODEJS_AUTOBUILD_FLAGS environment variable.
It will give the user the ability to add some specific flags to OPENCV build.

In my case i would like to reduce the size of opencv build library, so my use case is to do : 
`export OPENCV4NODEJS_AUTOBUILD_FLAGS="-DBUILD_LIST=dnn"`

Which will deactivate all unneeded modules from the build.
I'm sure there are plenty of other use cases for this, and i tried to make it as generic as possible.

I will add some infos into README once it's merged here.