### PR TITLE
Added CUDA cmake flags to opencv when CUDA is found on the host machine

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -10,6 +10,10 @@ export function isAutoBuildDisabled() {
   return !!process.env.OPENCV4NODEJS_DISABLE_AUTOBUILD
 }
 
+export function buildWithCuda() : boolean {
+  return !!process.env.OPENCV4NODEJS_BUILD_CUDA || false;
+}
+
 export function isWithoutContrib() {
   return !!process.env.OPENCV4NODEJS_AUTOBUILD_WITHOUT_CONTRIB
 }

--- a/src/setupOpencv.ts
+++ b/src/setupOpencv.ts
@@ -6,7 +6,7 @@ import { dirs } from './dirs';
 import { autoBuildFlags, numberOfCoresAvailable, opencvVersion, parseAutoBuildFlags, isWithoutContrib } from './env';
 import { findMsBuild } from './findMsBuild';
 import { AutoBuildFile } from './types';
-import { exec, isWin, spawn } from './utils';
+import { exec, isWin, spawn, isCudaAvailable } from './utils';
 
 const log = require('npmlog')
 
@@ -44,6 +44,15 @@ function getRunBuildCmd(msbuildExe: string): () => Promise<void> {
   }
 }
 
+function getCudaCmakeFlags() {
+  return [
+    '-DWITH_CUDA=ON',
+    '-DBUILD_opencv_cudacodec=OFF', // video codec (NVCUVID) is deprecated in cuda 10, so don't add it
+    '-DCUDA_FAST_MATH=ON', // optional
+    '-DWITH_CUBLAS=ON', // optional
+  ];
+}
+
 function getSharedCmakeFlags() {
   const conditionalFlags = isWithoutContrib()
     ? []
@@ -51,6 +60,12 @@ function getSharedCmakeFlags() {
       '-DOPENCV_ENABLE_NONFREE=ON',
       `-DOPENCV_EXTRA_MODULES_PATH=${dirs.opencvContribModules}`
     ]
+
+  if (isCudaAvailable()) {
+    log.info('install', 'Adding CUDA flags...');
+    conditionalFlags.concat(getCudaCmakeFlags());
+  }
+
   return defaultCmakeFlags
     .concat(conditionalFlags)
     .concat(parseAutoBuildFlags())
@@ -95,10 +110,13 @@ function writeAutoBuildFile() {
 }
 
 export async function setupOpencv() {
+  const msbuild = await getMsbuildIfWin()
+
+  // Get cmake flags here to check for CUDA early on instead of the start of the building process
+  const cMakeFlags = isWin() ? getWinCmakeFlags(msbuild.version) : getSharedCmakeFlags();
+  
   const tag = opencvVersion()
   log.info('install', 'installing opencv version %s into directory: %s', tag, dirs.opencvRoot)
-
-  const msbuild = await getMsbuildIfWin()
 
   await exec(getMkDirCmd('opencv'), { cwd: dirs.rootDir })
   await exec(getRmDirCmd('build'), { cwd: dirs.opencvRoot })
@@ -113,7 +131,7 @@ export async function setupOpencv() {
   }
   await spawn('git', ['clone', '-b', `${tag}`, '--single-branch', '--depth',  '1', '--progress', opencvRepoUrl], { cwd: dirs.opencvRoot })
 
-  await spawn('cmake', getCmakeArgs(isWin() ? getWinCmakeFlags(msbuild.version) : getSharedCmakeFlags()), { cwd: dirs.opencvBuild })
+  await spawn('cmake', getCmakeArgs(cMakeFlags), { cwd: dirs.opencvBuild })
   await getRunBuildCmd(isWin() ? msbuild.path : undefined)()
 
   writeAutoBuildFile()

--- a/src/setupOpencv.ts
+++ b/src/setupOpencv.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { getLibs } from '.';
 import { cmakeArchs, cmakeVsCompilers, defaultCmakeFlags, opencvContribRepoUrl, opencvRepoUrl } from './constants';
 import { dirs } from './dirs';
-import { autoBuildFlags, numberOfCoresAvailable, opencvVersion, parseAutoBuildFlags, isWithoutContrib } from './env';
+import { autoBuildFlags, numberOfCoresAvailable, opencvVersion, parseAutoBuildFlags, isWithoutContrib, buildWithCuda } from './env';
 import { findMsBuild } from './findMsBuild';
 import { AutoBuildFile } from './types';
 import { exec, isWin, spawn, isCudaAvailable } from './utils';
@@ -61,7 +61,7 @@ function getSharedCmakeFlags() {
       `-DOPENCV_EXTRA_MODULES_PATH=${dirs.opencvContribModules}`
     ]
 
-  if (isCudaAvailable()) {
+  if (buildWithCuda() && isCudaAvailable()) {
     log.info('install', 'Adding CUDA flags...');
     conditionalFlags.concat(getCudaCmakeFlags());
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import * as child_process from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 
 const log = require('npmlog')
 
@@ -77,3 +79,31 @@ export function isOSX() {
 export function isUnix() {
   return !isWin() && !isOSX()
 }
+
+export async function isCudaAvailable() {
+  log.info('install', 'Check if CUDA is available & what version...');
+
+  if (isWin()) {
+    try {
+      await requireCmd('nvcc --version', 'CUDA availability check');
+      return true;
+    } catch (err) {
+      log.info('install', 'Seems like CUDA is not installed.');
+      return false;
+    }
+  }
+
+  // Because NVCC is not installed by default & requires an extra install step,
+  // this is work around that always works
+  const cudaVersionFilePath = path.resolve('/usr/local/cuda/version.txt');
+
+  if (fs.existsSync(cudaVersionFilePath)) {
+    const content = fs.readFileSync(cudaVersionFilePath, 'utf8');
+    log.info('install', content);
+    return true;
+  } else {
+    log.info('install', 'CUDA version file could not be found.');
+    return false;
+  }
+}
+ 


### PR DESCRIPTION
In relation with [this issue](https://github.com/justadudewhohacks/opencv4nodejs/issues/271) I added cmake flags to support CUDA in opencv. I'm not sure autoinstall of cuda in the script is possible. Either way there should probably be an option to choose if you want to use CUDA or not since the build takes much longer with CUDA and this implementation is just naively checking if CUDA is installed, but should be good to get things going I think.

If you have any suggestions or any remarks, please let me know :)

