### PR TITLE
BUGFIX: CUDA flags not added to the sharedCmakeFlagsArray

### DIFF
--- a/src/setupOpencv.ts
+++ b/src/setupOpencv.ts
@@ -54,7 +54,7 @@ function getCudaCmakeFlags() {
 }
 
 function getSharedCmakeFlags() {
-  const conditionalFlags = isWithoutContrib()
+  let conditionalFlags = isWithoutContrib()
     ? []
     : [
       '-DOPENCV_ENABLE_NONFREE=ON',
@@ -63,7 +63,7 @@ function getSharedCmakeFlags() {
 
   if (buildWithCuda() && isCudaAvailable()) {
     log.info('install', 'Adding CUDA flags...');
-    conditionalFlags.concat(getCudaCmakeFlags());
+    conditionalFlags = conditionalFlags.concat(getCudaCmakeFlags());
   }
 
   return defaultCmakeFlags
@@ -114,7 +114,7 @@ export async function setupOpencv() {
 
   // Get cmake flags here to check for CUDA early on instead of the start of the building process
   const cMakeFlags = isWin() ? getWinCmakeFlags(msbuild.version) : getSharedCmakeFlags();
-  
+
   const tag = opencvVersion()
   log.info('install', 'installing opencv version %s into directory: %s', tag, dirs.opencvRoot)
 


### PR DESCRIPTION
Due to a busy schedule with school and work I didn't have the time to really use this package in the opencv4nodejs until today but I discovered a bug that the CUDA flags not were added to the cmakeSharedFlags. I thought concat would work the same as spread operator but apparently concat returns a fresh array instead of modifying the existing array.

I fixed it in this PR.