### PR TITLE
autobuild flags in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ npm install --global windows-build-tools
 ```
 
 ## Custom flags
-it's possible to specify custom flags to build process inserting on the `package.json` where the dependency is declared an object like:
+It's possible to specify custom flags to build process inserting on the `package.json` where the dependency is declared an object like:
 ```json
 {
   ...
   "opencv4nodejs": {
-    "flags": "-DOPENCV_GENERATE_PKGCONFIG=ON -DOPENCV_PC_FILE_NAME=opencv.pc"
+    "autoBuildFlags": "-DOPENCV_GENERATE_PKGCONFIG=ON -DOPENCV_PC_FILE_NAME=opencv.pc"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ npm install opencv-build
 ``` bash
 npm install --global windows-build-tools
 ```
+
+## Custom flags
+it's possible to specify custom flags to build process inserting on the `package.json` where the dependency is declared an object like:
+```json
+{
+  ...
+  "opencv4nodejs": {
+    "flags": "-DOPENCV_GENERATE_PKGCONFIG=ON -DOPENCV_PC_FILE_NAME=opencv.pc"
+  }
+}
+```
+these flags will be used during building in the same way as described [here](https://github.com/justadudewhohacks/opencv4nodejs#auto-build-flags).

--- a/build/install.js
+++ b/build/install.js
@@ -78,11 +78,11 @@ function install() {
                             if (process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS) {
                                 process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = [
                                     process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS,
-                                    rootPackageJSON.opencv4nodejs.flags
+                                    rootPackageJSON.opencv4nodejs.autoBuildFlags
                                 ].join(' ');
                             }
                             else {
-                                process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = rootPackageJSON.opencv4nodejs.flags;
+                                process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = rootPackageJSON.opencv4nodejs.autoBuildFlags;
                             }
                         }
                     }

--- a/build/install.js
+++ b/build/install.js
@@ -67,10 +67,25 @@ function checkInstalledLibs(autoBuildFile) {
 }
 function install() {
     return __awaiter(this, void 0, void 0, function () {
-        var autoBuildFile, hasLibs, err_1;
+        var rootPackageJSON, autoBuildFile, hasLibs, err_1;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
+                    if (process.env.INIT_CWD) {
+                        rootPackageJSON = require(path.resolve(process.env.INIT_CWD, 'package.json'));
+                        if (rootPackageJSON.opencv4nodejs &&
+                            rootPackageJSON.opencv4nodejs.autoBuildFlags) {
+                            if (process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS) {
+                                process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = [
+                                    process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS,
+                                    rootPackageJSON.opencv4nodejs.flags
+                                ].join(' ');
+                            }
+                            else {
+                                process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = rootPackageJSON.opencv4nodejs.flags;
+                            }
+                        }
+                    }
                     if (env_1.isAutoBuildDisabled()) {
                         log.info('install', 'OPENCV4NODEJS_DISABLE_AUTOBUILD is set');
                         log.info('install', 'skipping auto build...');

--- a/install.js
+++ b/install.js
@@ -3,5 +3,22 @@ if (process.env.npm_config_loglevel === 'silly') {
 }
 
 const { install } = require('./build/install')
+  , {resolve} = require('path')
+  , rootPackageJSON = require(resolve(process.env.INIT_CWD, 'package.json'))
+
+if (rootPackageJSON.opencv4nodejs &&
+  rootPackageJSON.opencv4nodejs.flags) {
+
+  if (process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS) {
+
+    process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = [
+      process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS,
+      rootPackageJSON.opencv4nodejs.flags
+    ].join(' ')
+  } else {
+
+    process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = rootPackageJSON.opencv4nodejs.flags
+  }
+}
 
 install()

--- a/install.js
+++ b/install.js
@@ -3,22 +3,5 @@ if (process.env.npm_config_loglevel === 'silly') {
 }
 
 const { install } = require('./build/install')
-  , {resolve} = require('path')
-  , rootPackageJSON = require(resolve(process.env.INIT_CWD, 'package.json'))
-
-if (rootPackageJSON.opencv4nodejs &&
-  rootPackageJSON.opencv4nodejs.flags) {
-
-  if (process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS) {
-
-    process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = [
-      process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS,
-      rootPackageJSON.opencv4nodejs.flags
-    ].join(' ')
-  } else {
-
-    process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = rootPackageJSON.opencv4nodejs.flags
-  }
-}
 
 install()

--- a/src/install.ts
+++ b/src/install.ts
@@ -38,6 +38,25 @@ function checkInstalledLibs(autoBuildFile: AutoBuildFile) {
 }
 
 export async function install() {
+  if (process.env.INIT_CWD) {
+    let rootPackageJSON = require(path.resolve(process.env.INIT_CWD, 'package.json'))
+
+    if (rootPackageJSON.opencv4nodejs &&
+      rootPackageJSON.opencv4nodejs.autoBuildFlags) {
+
+      if (process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS) {
+
+        process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = [
+          process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS,
+          rootPackageJSON.opencv4nodejs.flags
+        ].join(' ')
+      } else {
+
+        process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = rootPackageJSON.opencv4nodejs.flags
+      }
+    }
+  }
+
   if (isAutoBuildDisabled()) {
     log.info('install', 'OPENCV4NODEJS_DISABLE_AUTOBUILD is set')
     log.info('install', 'skipping auto build...')

--- a/src/install.ts
+++ b/src/install.ts
@@ -48,11 +48,11 @@ export async function install() {
 
         process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = [
           process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS,
-          rootPackageJSON.opencv4nodejs.flags
+          rootPackageJSON.opencv4nodejs.autoBuildFlags
         ].join(' ')
       } else {
 
-        process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = rootPackageJSON.opencv4nodejs.flags
+        process.env.OPENCV4NODEJS_AUTOBUILD_FLAGS = rootPackageJSON.opencv4nodejs.autoBuildFlags
       }
     }
   }


### PR DESCRIPTION
Hi, 

thanks for making opencv compilation process easy to handle. For a personal need (pkg-config file creation), I have to enable some cmake flags. I already saw the autobuild flags way but setting an environment variable before the install script was run did not propagate the variables to the install.js script. 
What I did was something like:
```json
{
  "name": "my-project-where-i-ll-using-opencv",
  "scripts": {
    "preinstall": "export OPENCV4NODEJS_AUTOBUILD_FLAGS='...'"
}
```
I also tried this way:
```json
{
  "name": "my-project-where-i-ll-using-opencv",
  "scripts": {
    "install": "export OPENCV4NODEJS_AUTOBUILD_FLAGS='...'"
}
```
In the first scenario, nothing was read by the build process; in the latter "install" stage is before the installation of dependencies so it's useless.
 
In the end, I choose for setting the flags into dependent `package.json` like this:
```json
{
  "name": "my-project-where-i-ll-using-opencv",
  "opencv4nodejs": {
      "flags": "-DOPENCV_GENERATE_PKGCONFIG=ON -DOPENCV_PC_FILE_NAME=opencv.pc"
  }
}
```

This PR bring this logic into the module setting the environment variable following the "flags" property.

Hope this will help as helped me.
Have a great day

Dario 