### PR TITLE
Treat DISABLE_AUTOBUILD as number

### DIFF
--- a/build/env.js
+++ b/build/env.js
@@ -6,7 +6,7 @@ var path = require("path");
 var dirs_1 = require("./dirs");
 var log = require('npmlog');
 function isAutoBuildDisabled() {
-    return !!process.env.OPENCV4NODEJS_DISABLE_AUTOBUILD;
+    return !!Number(process.env.OPENCV4NODEJS_DISABLE_AUTOBUILD);
 }
 exports.isAutoBuildDisabled = isAutoBuildDisabled;
 function buildWithCuda() {


### PR DESCRIPTION
`!!"0"` equals to `true` which does not feel correct when trying to disable the flag.
`unset OPENCV4NODEJS_DISABLE_AUTOBUILD` is the only way to disable it as it stands now.