### PR TITLE
Fix lib name regex to allow any version number between 0 and 6 digits

### DIFF
--- a/src/getLibsFactory.ts
+++ b/src/getLibsFactory.ts
@@ -17,7 +17,7 @@ export function getLibsFactory(
   }
 
   function getLibNameRegex(opencvModuleName: string) {
-    return new RegExp(`^${getLibPrefix()}${opencvModuleName}[0-9]{0,3}.${getLibSuffix()}$`)
+    return new RegExp(`^${getLibPrefix()}${opencvModuleName}[0-9]{0,6}.${getLibSuffix()}$`)
   }
 
   function createLibResolver(libDir: string): (libFile: string) => string | undefined {


### PR DESCRIPTION
The current regular expression only support version numbers between 0 and 3 digits.
To future proof the regex we allow the major, minor, and patch numbers to consist of up to 2 digits.