### PR TITLE
Adapt to the latest version, such as 4.10.0

### DIFF
--- a/src/getLibsFactory.ts
+++ b/src/getLibsFactory.ts
@@ -17,7 +17,7 @@ export function getLibsFactory(
   }
 
   function getLibNameRegex(opencvModuleName: string) {
-    return new RegExp(`^${getLibPrefix()}${opencvModuleName}[0-9]{0,3}.${getLibSuffix()}$`)
+    return new RegExp(`^${getLibPrefix()}${opencvModuleName}[0-9]{0,}.${getLibSuffix()}$`)
   }
 
   function createLibResolver(libDir: string): (libFile: string) => string | undefined {


### PR DESCRIPTION
[0-9]{0,3} match only x.x.x , but the latest version of opencv has been updated to 4.10.0.

https://github.com/opencv/opencv/releases/